### PR TITLE
Small cli improvements

### DIFF
--- a/cmd/args/common.go
+++ b/cmd/args/common.go
@@ -65,7 +65,6 @@ func BindCommonArgs(flags *pflag.FlagSet) {
 	fileSettings.AddConfigPath(".")
 	fileSettings.AddConfigPath("$HOME")
 
-	fileSettings.SetDefault("country", "US")
 	fileSettings.SetDefault("signature-algorithm", "sha256")
 
 	if err := fileSettings.ReadInConfig(); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,8 @@ func init() {
 	viper.AutomaticEnv()
 
 	args.BindCommonArgs(rootCmd.PersistentFlags())
+	rootCmd.MarkPersistentFlagRequired("key")
+	rootCmd.MarkPersistentFlagRequired("common-name")
 
 	rootCmd.AddCommand(RSA)
 	initRSA()


### PR DESCRIPTION
Fixes 2 small issues with the tool:
- The only flag that has a default is `country`, which is not required in a csr. Remove this flag.
- The tool will panic if the `key` flag isn't set. Make it required.
- The `common-name` flag should also be required.